### PR TITLE
setting maximum precision as default

### DIFF
--- a/src/mudirac.cpp
+++ b/src/mudirac.cpp
@@ -210,10 +210,12 @@ int main(int argc, char *argv[]) {
 
     out << "# Z = " << da.getZ() << ", A = " << da.getA() << " amu, m = " << da.getm() << " au\n";
     out << "Line\tDeltaE (eV)\tW_12 (s^-1)\n";
+    out << fixed;
 
     if (config.getIntValue("xr_print_precision") > -1) {
-      out << fixed;
       out << setprecision(config.getIntValue("xr_print_precision"));
+    } else {
+      out << setprecision(15); //Setting the maximum precision
     }
 
     for (int i = 0; i < transitions.size(); ++i) {


### PR DESCRIPTION
By default c++ round and trim the output, forcing output precision to be 15 (maximum precision,) if the defalt xr_print_precision value is -1, which is the default behaviour accordig to documentation.