### PR TITLE
Fix bug where blank lines in the input file cause a segmentation fault

### DIFF
--- a/lib/input.cpp
+++ b/lib/input.cpp
@@ -277,6 +277,11 @@ void InputFile::parseFile(string path) {
   ifstream ifile(path);
 
   while (getline(ifile, line)) {
+
+    // Catch empty lines before trying to split
+    if (line.size() == 0)
+      continue;
+
     // Remove comments
     line = splitString(line, "#")[0];
     line = stripString(line);


### PR DESCRIPTION
A bug was occurring where a blank line in the .in file was causing a segmentation fault in the file parsing. This is fixed by checking for a line size of 0 _before_ the line is split and stripped. 