### PR TITLE
Read in experimental xray results file

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -12,11 +12,12 @@ add_library(input STATIC input.cpp)
 add_library(output STATIC output.cpp)
 add_library(wavefunction STATIC wavefunction.cpp)
 add_library(config STATIC config.cpp)
+add_library(experiment STATIC experiment.cpp)
 add_library(debugtasks STATIC debugtasks.cpp)
 
 # Define interface library
 add_library(mudiraclib INTERFACE)
-target_link_libraries(mudiraclib INTERFACE debugtasks config output
+target_link_libraries(mudiraclib INTERFACE debugtasks config experiment output
                       atom boundary state potential
                       econfigs hydrogenic transforms 
                       wavefunction integrate elements input utils)

--- a/lib/experiment.cpp
+++ b/lib/experiment.cpp
@@ -6,8 +6,8 @@
  *
  * Functions and classes useful for interpreting experimental results files
  *
- * @author Simone Sturniolo
- * @version 1.0 20/03/2020
+ * @author Milan Kumar
+ * @version 1.0 09/05/2025
  */
 
 #include "experiment.hpp"

--- a/lib/experiment.cpp
+++ b/lib/experiment.cpp
@@ -20,6 +20,4 @@ ExperimentalResultFile::ExperimentalResultFile() : InputFile() {
   this->defineDoubleNode("xr_energy", InputNode<double>(vector<double> {0}, false)); // experimentally measured xray energies
   this->defineDoubleNode("xr_error", InputNode<double>(vector<double> {0}, false)); // energy uncertainty for the measured xrays
 
-  /* These keywords are reserved for developers and debugging */
-
 }

--- a/lib/experiment.cpp
+++ b/lib/experiment.cpp
@@ -1,0 +1,25 @@
+/**
+ * MuDirac - A muonic atom Dirac equation solver
+ * by Simone Sturniolo (2019-2020)
+ *
+ * experiment.cpp
+ *
+ * Functions and classes useful for interpreting experimental results files
+ *
+ * @author Simone Sturniolo
+ * @version 1.0 20/03/2020
+ */
+
+#include "experiment.hpp"
+
+ExperimentalResultFile::ExperimentalResultFile() : InputFile() {
+  // Vector string keywords
+  this->defineStringNode("xr_lines", InputNode<string>(vector<string> {"K1-L2"}, false)); // List of spectral lines experimentally measured
+  
+  // Vector double keywords
+  this->defineDoubleNode("xr_energy", InputNode<double>(vector<double>{0}, false)); // experimentally measured xray energies
+  this->defineDoubleNode("xr_error", InputNode<double>(vector<double>{0}, false)); // energy uncertainty for the measured xrays
+
+  /* These keywords are reserved for developers and debugging */
+
+}

--- a/lib/experiment.cpp
+++ b/lib/experiment.cpp
@@ -14,7 +14,7 @@
 
 ExperimentalResultFile::ExperimentalResultFile() : InputFile() {
   // Vector string keywords
-  this->defineStringNode("xr_lines", InputNode<string>(vector<string> {"K1-L2"}, false)); // List of spectral lines experimentally measured
+  this->defineStringNode("xr_lines", InputNode<string>(vector<string> {""}, false)); // List of spectral lines experimentally measured
 
   // Vector double keywords
   this->defineDoubleNode("xr_energy", InputNode<double>(vector<double> {0}, false)); // experimentally measured xray energies

--- a/lib/experiment.hpp
+++ b/lib/experiment.hpp
@@ -7,8 +7,8 @@
  * Functions and classes useful for interpreting experimental results files - header
  * file
  *
- * @author Simone Sturniolo
- * @version 1.0 20/03/2020
+ * @author Milan Kumar
+ * @version 1.0 09/05/2025
  */
 
 #include "input.hpp"

--- a/lib/experiment.hpp
+++ b/lib/experiment.hpp
@@ -1,0 +1,32 @@
+/**
+ * MuDirac - A muonic atom Dirac equation solver
+ * by Simone Sturniolo (2019-2020)
+ *
+ * experiment.hpp
+ *
+ * Functions and classes useful for interpreting experimental results files - header
+ * file
+ *
+ * @author Simone Sturniolo
+ * @version 1.0 20/03/2020
+ */
+
+#include "input.hpp"
+#include <vector>
+#include "../vendor/aixlog/aixlog.hpp"
+
+using namespace std;
+
+/**
+ * @class ExperimentalResultFile
+ *
+ * @brief  A specialised InputFile class for the experimental results input file in mudirac
+ * @note   A specialised InputFile class for the experimental results input file in mudirac.
+ * Initialises all the relevant keywords.
+ *
+ * @retval None
+ */
+class ExperimentalResultFile : public InputFile {
+  public:
+   ExperimentalResultFile(void);
+};

--- a/src/mudirac.cpp
+++ b/src/mudirac.cpp
@@ -105,33 +105,74 @@ int main(int argc, char *argv[]) {
   // The idea is that we will calculate all transition energies and rates for many different pairs
   // of the fermi parameters (c,t)
   // We can then use this to perform least squares optimisation and finally obtain the rms nuclear radius
-  if (config.getBoolValue("optimise_fermi_parameters") && config.getStringValue("nuclear_model") == "FERMI2") {
+  if (config.getBoolValue("optimise_fermi_parameters")){
+
+    // check the experimental results input file is provided
+    if (argc < 3){
+      cout << "Experimental results input file missing\n";
+      cout << "Please use the program as `mudirac <input_file> <experimental_results_input_file>`\n";
+      cout << "Quitting...\n";
+      return -1;
+    }
+
+    // check the nuclear model is suitable for optimisation
+    if (config.getStringValue("nuclear_model") != "FERMI2"){
+      cout << "nuclear model parameters can only be optimised for the 2 parameter Fermi model\n";
+      cout << "Please add the line `nuclear_model: FERMI2` to your first input file\n";
+      cout << "Quitting...\n";
+      return -1;
+    }
+
+    // try to read the experimental results file
     ExperimentalResultFile measurements;
     bool xr_measurement_read_success = false;
     try {
       measurements.parseFile(argv[2]);
+
+      // read the measured transition lines
       vector<string> xr_lines_measured = measurements.getStringValues("xr_lines");
       LOG(DEBUG) << "Reading experimental Xray measurments for transitions: ";
       for (auto transition: xr_lines_measured) {
         LOG(DEBUG) << transition << ", ";
       }
       LOG(DEBUG) << "\n";
-      vector<double> xr_energies = measurements.getDoubleValues("xr_energy");
 
+      // read the measured transition energies
+      vector<double> xr_energies = measurements.getDoubleValues("xr_energy");
       LOG(DEBUG) << "Reading experimental Xray energies: ";
       for (auto transition_energy: xr_energies) {
         LOG(DEBUG) << transition_energy << ", ";
       }
       LOG(DEBUG) << "\n";
 
+      // read the measured transition errors
       vector<double> xr_errors = measurements.getDoubleValues("xr_error");
-
       LOG(DEBUG) << "Reading experimental Xray energy errors: ";
       for (auto transition_energy_error: xr_errors) {
         LOG(DEBUG) << transition_energy_error << ", ";
       }
       LOG(DEBUG) << "\n";
-      xr_measurement_read_success = true;
+
+      // checking that the file has contents and not the default values
+      LOG(DEBUG) << "Validating experimental results input \n";
+      if (xr_lines_measured[0] == ""){
+        cout << "Experimental results input file is empty\n";
+        cout << "Please check the filename of the experimental results input file \n";
+        cout << "Quitting...\n";
+        return -1;
+      }
+
+      // check that the data provided is complete: all transitions measured have energies and errors
+      if (xr_lines_measured.size() == xr_energies.size() && xr_energies.size() == xr_errors.size()) {
+        xr_measurement_read_success = true;
+      }
+      else {
+        cout << "Invalid experimental measurements file: Missing input values\n";
+        cout << "please check energies and errors are listed for each xray transition line \n";
+        cout << "Quitting...\n";
+        return -1;
+
+      }
 
     } catch (runtime_error e) {
       cout << "Invalid experimental measurements file:\n";

--- a/src/mudirac.cpp
+++ b/src/mudirac.cpp
@@ -106,7 +106,42 @@ int main(int argc, char *argv[]) {
   // The idea is that we will calculate all transition energies and rates for many different pairs
   // of the fermi parameters (c,t)
   // We can then use this to perform least squares optimisation and finally obtain the rms nuclear radius
-  if (config.getBoolValue("optimise_fermi_parameters") && config.getStringValue("nuclear_model") == "fermi2"){
+  if (config.getBoolValue("optimise_fermi_parameters") && config.getStringValue("nuclear_model") == "FERMI2"){
+    ExperimentalResultFile measurements;
+    bool xr_measurement_read_success = false;
+    try {
+      measurements.parseFile(argv[2]);
+      vector<string> xr_lines_measured = measurements.getStringValues("xr_lines");
+      LOG(DEBUG) << "Reading experimental Xray measurments for transitions: ";
+      for (auto transition: xr_lines_measured){
+        LOG(DEBUG) << transition << ", ";
+      }
+      LOG(DEBUG) << "\n";
+      vector<double> xr_energies = measurements.getDoubleValues("xr_energy");
+
+      LOG(DEBUG) << "Reading experimental Xray energies: ";
+      for (auto transition_energy: xr_energies){
+        LOG(DEBUG) << transition_energy << ", ";
+      }
+      LOG(DEBUG) << "\n";
+
+      vector<double> xr_errors = measurements.getDoubleValues("xr_error");
+
+      LOG(DEBUG) << "Reading experimental Xray energy errors: ";
+      for (auto transition_energy_error: xr_errors){
+        LOG(DEBUG) << transition_energy_error << ", ";
+      }
+      LOG(DEBUG) << "\n";
+      xr_measurement_read_success = true;
+
+    } catch (runtime_error e) {
+      cout << "Invalid experimental measurements file:\n";
+      cout << e.what() << "\n";
+      return -1;
+    }
+
+    if (xr_measurement_read_success){
+      LOG(DEBUG) << "Successfully read xray measurements input file \n";
 
     // In here, we will need to loop over the pairs of (c,t) values
     // An appropriate (c,t) grid resolution will need to be chosen, as well as an appropriate range
@@ -119,8 +154,9 @@ int main(int argc, char *argv[]) {
     // least squares optimise
     // 
     // We also need to decide on what happens after this optimisation. Do we print out the energies and rates
-    // for the optimal pair of parameters?
+    // for the optimal pair of parameters?  
 
+    }
 
   }else{
     // Default mudirac behaviour

--- a/src/mudirac.cpp
+++ b/src/mudirac.cpp
@@ -105,10 +105,10 @@ int main(int argc, char *argv[]) {
   // The idea is that we will calculate all transition energies and rates for many different pairs
   // of the fermi parameters (c,t)
   // We can then use this to perform least squares optimisation and finally obtain the rms nuclear radius
-  if (config.getBoolValue("optimise_fermi_parameters")){
+  if (config.getBoolValue("optimise_fermi_parameters")) {
 
     // check the experimental results input file is provided
-    if (argc < 3){
+    if (argc < 3) {
       cout << "Experimental results input file missing\n";
       cout << "Please use the program as `mudirac <input_file> <experimental_results_input_file>`\n";
       cout << "Quitting...\n";
@@ -116,7 +116,7 @@ int main(int argc, char *argv[]) {
     }
 
     // check the nuclear model is suitable for optimisation
-    if (config.getStringValue("nuclear_model") != "FERMI2"){
+    if (config.getStringValue("nuclear_model") != "FERMI2") {
       cout << "nuclear model parameters can only be optimised for the 2 parameter Fermi model\n";
       cout << "Please add the line `nuclear_model: FERMI2` to your first input file\n";
       cout << "Quitting...\n";
@@ -155,7 +155,7 @@ int main(int argc, char *argv[]) {
 
       // checking that the file has contents and not the default values
       LOG(DEBUG) << "Validating experimental results input \n";
-      if (xr_lines_measured[0] == ""){
+      if (xr_lines_measured[0] == "") {
         cout << "Experimental results input file is empty\n";
         cout << "Please check the filename of the experimental results input file \n";
         cout << "Quitting...\n";
@@ -165,8 +165,7 @@ int main(int argc, char *argv[]) {
       // check that the data provided is complete: all transitions measured have energies and errors
       if (xr_lines_measured.size() == xr_energies.size() && xr_energies.size() == xr_errors.size()) {
         xr_measurement_read_success = true;
-      }
-      else {
+      } else {
         cout << "Invalid experimental measurements file: Missing input values\n";
         cout << "please check energies and errors are listed for each xray transition line \n";
         cout << "Quitting...\n";

--- a/src/mudirac.cpp
+++ b/src/mudirac.cpp
@@ -110,7 +110,9 @@ int main(int argc, char *argv[]) {
     // check the experimental results input file is provided
     if (argc < 3) {
       cout << "Experimental results input file missing\n";
+      cout << "When optimise_fermi_parameters is True, an additional experimental results file is expected\n";
       cout << "Please use the program as `mudirac <input_file> <experimental_results_input_file>`\n";
+      cout << "If experimental results cannot be provided, optimise_fermi_parameters should be set to False \n";
       cout << "Quitting...\n";
       return -1;
     }

--- a/src/mudirac.cpp
+++ b/src/mudirac.cpp
@@ -12,6 +12,7 @@
 
 #include "mudirac.hpp"
 
+
 int main(int argc, char *argv[]) {
   string seed = "mudirac";
   MuDiracInputFile config;

--- a/src/mudirac.hpp
+++ b/src/mudirac.hpp
@@ -32,7 +32,6 @@
 
 using namespace std;
 
-
 struct TransLineSpec {
   int n1, n2;
   int l1, l2;

--- a/src/mudirac.hpp
+++ b/src/mudirac.hpp
@@ -19,6 +19,7 @@
 #include <cmath>
 #include <chrono>
 #include "../lib/config.hpp"
+#include "../lib/experiment.hpp"
 #include "../lib/atom.hpp"
 #include "../lib/output.hpp"
 #include "../lib/utils.hpp"

--- a/src/mudirac.in.hpp
+++ b/src/mudirac.in.hpp
@@ -19,6 +19,7 @@
 #include <cmath>
 #include <chrono>
 #include "../lib/config.hpp"
+#include "../lib/experiment.hpp"
 #include "../lib/atom.hpp"
 #include "../lib/output.hpp"
 #include "../lib/utils.hpp"

--- a/src/mudirac.in.hpp
+++ b/src/mudirac.in.hpp
@@ -37,3 +37,6 @@ struct TransLineSpec {
   int l1, l2;
   bool s1, s2;
 };
+
+vector<TransitionData> getAllTransitions(vector<TransLineSpec> transqnums, DiracAtom da);
+vector<TransLineSpec> parseXRLines(MuDiracInputFile config);


### PR DESCRIPTION
This PR adds a subclass of input to read a new input file containing experimental results containing xray transitions energies and uncertainties from negative muon experiments. This input file is a temporary placeholder for when a standard is agreed in the muon community, such as NeXuS. 

This PR allows the new input file to be read if the user chooses to optimise the fermi parameters. The values are then recorded in the LOG. The actual routine for optimisation will be added in a subsequent PR. 

The changes can be tested using ctest and the default behaviour of MuDirac remains unchanged. 