### PR TITLE
Add reduced mass keyword input

### DIFF
--- a/lib/atom.cpp
+++ b/lib/atom.cpp
@@ -106,7 +106,7 @@ Atom::Atom(int Z, double m, int A, NuclearRadiusModel radius_model,
 
   if (A > 0) {
     M = getIsotopeMass(Z, A);
-    if (reduced_mass){
+    if (reduced_mass) {
       mu = effectiveMass(m, M * Physical::amu);
     } else {
       mu = m;

--- a/lib/atom.cpp
+++ b/lib/atom.cpp
@@ -85,13 +85,14 @@ double TransitionMatrix::totalRate() {
  * @retval
  */
 Atom::Atom(int Z, double m, int A, NuclearRadiusModel radius_model,
-           double radius, double fc, double dx) {
+           double radius, double fc, double dx, bool reduced_mass) {
   // Set the properties
   this->Z = Z;
   this->A = A;
   this->m = m;
   rmodel = radius_model;
 
+  this->reduced_mass = reduced_mass;
   // Sanity checks
   if (Z <= 0) {
     throw invalid_argument("Z must be positive");
@@ -105,7 +106,11 @@ Atom::Atom(int Z, double m, int A, NuclearRadiusModel radius_model,
 
   if (A > 0) {
     M = getIsotopeMass(Z, A);
-    mu = effectiveMass(m, M * Physical::amu);
+    if (reduced_mass){
+      mu = effectiveMass(m, M * Physical::amu);
+    } else {
+      mu = m;
+    }
   } else {
     mu = m;
   }
@@ -340,8 +345,8 @@ double Atom::sphereNuclearModel(int Z, int A) {
  * @retval
  */
 DiracAtom::DiracAtom(int Z, double m, int A, NuclearRadiusModel radius_model,
-                     double radius, double fc, double dx, int ideal_minshell)
-  : Atom(Z, m, A, radius_model, radius, fc, dx) {
+                     double radius, double fc, double dx, int ideal_minshell, bool reduced_mass)
+  : Atom(Z, m, A, radius_model, radius, fc, dx, reduced_mass) {
   restE = mu * pow(Physical::c, 2);
   LOG(DEBUG) << "Rest energy = " << restE / Physical::eV << " eV\n";
   idshell = ideal_minshell;

--- a/lib/atom.hpp
+++ b/lib/atom.hpp
@@ -95,6 +95,7 @@ class Atom {
   double m, M, mu;           // Mass of the orbiting particle (e.g. muon, electron), of the nucleus, and effective mass of the system
   double R;                  // Nuclear radius
   NuclearRadiusModel rmodel; // Nuclear model
+  bool reduced_mass;        // turn on reduced mass
 
   //Grid
   double rc = 1.0;   // Central radius
@@ -111,7 +112,7 @@ class Atom {
 
  public:
   Atom(int Z = 1, double m = 1, int A = -1, NuclearRadiusModel radius_model = POINT,
-       double radius = -1, double fc = 1.0,double dx = 0.005);
+       double radius = -1, double fc = 1.0,double dx = 0.005, bool reduced_mass = true);
 
   // Basic getters
   double getZ() {
@@ -188,7 +189,7 @@ class DiracAtom : public Atom {
   int min_n = 1000;
 
   DiracAtom(int Z = 1, double m = 1, int A = -1, NuclearRadiusModel radius_model = POINT,
-            double radius = -1, double fc = 1.0, double dx = 0.005, int ideal_minshell = -1);
+            double radius = -1, double fc = 1.0, double dx = 0.005, int ideal_minshell = -1, bool reduced_mass = true);
 
   double getRestE() {
     return restE;

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -74,7 +74,7 @@ MuDiracInputFile::MuDiracInputFile() : InputFile() {
 
   // Boolean keywords
   this->defineBoolNode("devel_EdEscan_log", InputNode<bool>(false, false)); // Make the energy scan logarithmic
-  this->defineBoolNode("reduced_mass", InputNode<bool>(false, false)); // Use the reduced mass
+  this->defineBoolNode("reduced_mass", InputNode<bool>(true, false)); // Use the reduced mass
 }
 
 DiracAtom MuDiracInputFile::makeAtom() {
@@ -85,6 +85,7 @@ DiracAtom MuDiracInputFile::makeAtom() {
   double c_param = this->getDoubleValue("fermi_c");
   double m = this->getDoubleValue("mass");
   int A = this->getIntValue("isotope");
+  bool reduced_mass = this->getBoolValue("reduced_mass");
 
   if (A == -1) {
     A = getElementMainIsotope(Z);
@@ -106,7 +107,7 @@ DiracAtom MuDiracInputFile::makeAtom() {
 
   // Prepare the DiracAtom
   DiracAtom da;
-  da = DiracAtom(Z, m, A, nucmodel, radius, fc, dx, idshell);
+  da = DiracAtom(Z, m, A, nucmodel, radius, fc, dx, idshell, reduced_mass);
   da.Etol = this->getDoubleValue("energy_tol");
   da.Edamp = this->getDoubleValue("energy_damp");
   da.max_dE_ratio = this->getDoubleValue("max_dE_ratio");

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -74,6 +74,7 @@ MuDiracInputFile::MuDiracInputFile() : InputFile() {
 
   // Boolean keywords
   this->defineBoolNode("devel_EdEscan_log", InputNode<bool>(false, false)); // Make the energy scan logarithmic
+  this->defineBoolNode("reduced_mass", InputNode<bool>(false, false)); // Use the reduced mass
 }
 
 DiracAtom MuDiracInputFile::makeAtom() {

--- a/test/test_atom.cpp
+++ b/test/test_atom.cpp
@@ -43,6 +43,15 @@ TEST_CASE("Dirac Atom - basics", "[DiracAtom]")
   REQUIRE(da.getRestE() == da.getmu() * pow(Physical::c, 2));
 }
 
+TEST_CASE("Dirac Atom - full mass", "[DiracAtom]")
+{
+  double Z = 1;
+  double m = 1;
+  double A = 1;
+  DiracAtom da = DiracAtom(Z, m, A, POINT, -1, 1, 0.005, -1, false);
+  REQUIRE (da.getmu() == m);
+}
+
 TEST_CASE("Dirac Atom - grid", "[DiracAtom]")
 {
   AixLog::Log::init<AixLog::SinkCout>(AixLog::Severity::info,

--- a/test/test_atom.cpp
+++ b/test/test_atom.cpp
@@ -14,8 +14,7 @@
 
 using namespace std;
 
-TEST_CASE("Transition Matrix", "[TransitionMatrix]")
-{
+TEST_CASE("Transition Matrix", "[TransitionMatrix]") {
 
   AixLog::Log::init<AixLog::SinkCout>(AixLog::Severity::info,
                                       AixLog::Type::normal);
@@ -29,8 +28,7 @@ TEST_CASE("Transition Matrix", "[TransitionMatrix]")
   REQUIRE(tmat.T[0][0] == 0);
 }
 
-TEST_CASE("Dirac Atom - basics", "[DiracAtom]")
-{
+TEST_CASE("Dirac Atom - basics", "[DiracAtom]") {
   double Z = 1;
   double m = 1;
   double A = 1;
@@ -43,8 +41,7 @@ TEST_CASE("Dirac Atom - basics", "[DiracAtom]")
   REQUIRE(da.getRestE() == da.getmu() * pow(Physical::c, 2));
 }
 
-TEST_CASE("Dirac Atom - full mass", "[DiracAtom]")
-{
+TEST_CASE("Dirac Atom - full mass", "[DiracAtom]") {
   double Z = 1;
   double m = 1;
   double A = 1;
@@ -52,8 +49,7 @@ TEST_CASE("Dirac Atom - full mass", "[DiracAtom]")
   REQUIRE (da.getmu() == m);
 }
 
-TEST_CASE("Dirac Atom - grid", "[DiracAtom]")
-{
+TEST_CASE("Dirac Atom - grid", "[DiracAtom]") {
   AixLog::Log::init<AixLog::SinkCout>(AixLog::Severity::info,
                                       AixLog::Type::normal);
   double Z = 92;
@@ -74,8 +70,7 @@ TEST_CASE("Dirac Atom - grid", "[DiracAtom]")
   REQUIRE_THROWS(da.gridLimits(E0, k));
 }
 
-TEST_CASE("Dirac Atom - energy search", "[DiracAtom]")
-{
+TEST_CASE("Dirac Atom - energy search", "[DiracAtom]") {
 
   AixLog::Log::init<AixLog::SinkCout>(AixLog::Severity::info,
                                       AixLog::Type::normal);
@@ -114,8 +109,7 @@ TEST_CASE("Dirac Atom - energy search", "[DiracAtom]")
   REQUIRE(ds.E == Approx(Es2));
 }
 
-TEST_CASE("Dirac Atom - transitions", "[DiracAtom]")
-{
+TEST_CASE("Dirac Atom - transitions", "[DiracAtom]") {
   // Tests are carried out with an ideal hydrogen atom
   // Exact values are taken from NIST database
   DiracIdealAtom daH = DiracIdealAtom(1, 1, 1, NuclearRadiusModel::SPHERE);
@@ -142,7 +136,7 @@ TEST_CASE("Dirac Atom - transitions", "[DiracAtom]")
   // 3d3/2 => 3p1/2
   tmat = daFe.getTransitionProbabilities(3, 2, false, 3, 1, false);
   REQUIRE(
-      tmat.totalRate() * Physical::s ==
-      Approx(1.31e7).epsilon(
-          3e-2)); // Precision is not strong here... possibly needs improvement
+    tmat.totalRate() * Physical::s ==
+    Approx(1.31e7).epsilon(
+      3e-2)); // Precision is not strong here... possibly needs improvement
 }


### PR DESCRIPTION
This PR will add the keyword, "reduced_mass", to the configuration of MuDirac. This keyword controls the non relativistic recoil correction and ensures the user knows whether it has been applied or not. The default value is true. 

The correction should not interfere with the mass keyword which sets the muon mass. 

One test case has been added to test_atom.cpp to check the full mass is used when the reduced mass is set to false. 