### PR TITLE
add Ceres solver for 2pF optimisation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(MuDirac VERSION 1.0.1)
 
 # The standard is C++ 11

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -15,7 +15,8 @@ add_library(config STATIC config.cpp)
 add_library(experiment STATIC experiment.cpp)
 add_library(debugtasks STATIC debugtasks.cpp)
 add_library(optimisation STATIC optimisation.cpp)
-target_link_libraries(optimisation dlib::dlib experiment)
+find_package(Ceres)
+target_link_libraries(optimisation dlib::dlib Ceres::ceres experiment)
 
 
 

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -285,7 +285,7 @@ void MuDiracInputFile::validateOptimisation(int args, string &coords, string &mi
   // check the algorithm is valid
   min_2pF_algo = this->getStringValue("min_2pF_algorithm");
 
-  if (!((min_2pF_algo == "bfgs")||(min_2pF_algo == "global")||(min_2pF_algo == "trust")||(min_2pF_algo == "lm") )) {
+  if (!((min_2pF_algo == "bfgs")||(min_2pF_algo == "global")||(min_2pF_algo == "trust")||(min_2pF_algo == "lm") ||(min_2pF_algo == "ls"))) {
     LOG(WARNING)<< "Invalid 2pF algorithm for minimsation\n";
     LOG(WARNING)<< "please use \"bfgs\" or \"global\" (default is \"trust\") \n";
     LOG(WARNING)<< "You used: \""<<min_2pF_algo<<"\" \n";

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -285,7 +285,7 @@ void MuDiracInputFile::validateOptimisation(int args, string &coords, string &mi
   // check the algorithm is valid
   min_2pF_algo = this->getStringValue("min_2pF_algorithm");
 
-  if (!((min_2pF_algo == "bfgs")||(min_2pF_algo == "global")||(min_2pF_algo == "trust"))) {
+  if (!((min_2pF_algo == "bfgs")||(min_2pF_algo == "global")||(min_2pF_algo == "trust")||(min_2pF_algo == "lm") )) {
     LOG(WARNING)<< "Invalid 2pF algorithm for minimsation\n";
     LOG(WARNING)<< "please use \"bfgs\" or \"global\" (default is \"trust\") \n";
     LOG(WARNING)<< "You used: \""<<min_2pF_algo<<"\" \n";

--- a/lib/config.cpp
+++ b/lib/config.cpp
@@ -287,10 +287,10 @@ void MuDiracInputFile::validateOptimisation(int args, Fermi2CoordinateSystem & c
 
   if (!((min_2pF_algo == "bfgs")||(min_2pF_algo == "global")||(min_2pF_algo == "trust")||(min_2pF_algo == "lm") ||(min_2pF_algo == "ls"))) {
     LOG(WARNING)<< "Invalid 2pF algorithm for minimsation\n";
-    LOG(WARNING)<< "please use \"bfgs\" or \"global\" (default is \"trust\") \n";
+    LOG(WARNING)<< "please use \"lm\", \"ls\", \"bfgs\" or \"global\" (default is \"lm\") \n";
     LOG(WARNING)<< "You used: \""<<min_2pF_algo<<"\" \n";
-    LOG(INFO) << "Using default optimisation algorithm bfgs\n";
-    min_2pF_algo = "bfgs";
+    LOG(INFO) << "Using default optimisation algorithm lm\n";
+    min_2pF_algo = "lm";
   }
   LOG(DEBUG) << "Settings for optimisation are valid\n";
 }

--- a/lib/optimisation.cpp
+++ b/lib/optimisation.cpp
@@ -194,10 +194,9 @@ void optFermi2(DiracAtom & da, const string algo, double & opt_time) {
     trustOptimizeFermiParameters(opt_obj, da, opt_time);
   } else if (algo=="global") {
     globalOptimizeFermiParameters(da, opt_time);
-  } else if ((algo=="lm")|| (algo=="ls")){
+  } else if ((algo=="lm")|| (algo=="ls")) {
     ceresOptimizeFermiParameters(da, opt_time, algo);
-  } 
-  else {
+  } else {
     cout << "Invalid 2pF optimisation algorithm choice for minimsation\n";
     cout << "please use \"bfgs\", \"trust\", or \"lm\" (default is \"bfgs\") \n";
     cout << "You used: \""<<algo<<"\" \n";
@@ -233,30 +232,29 @@ void runFermiModelOptimisation(MuDiracInputFile & config, const int & argc, char
   writeFermiParameters(da, opt_time,  seed + "fermi_parameters.out", config.getIntValue("rms_radius_decimals"));
 }
 
-void ceresOptimizeFermiParameters(DiracAtom & da, double & opt_time, const string & algo){
+void ceresOptimizeFermiParameters(DiracAtom & da, double & opt_time, const string & algo) {
 
   LOG(INFO) << "optimizing fermi parameters using the ceres software" ;
   // Get initial guess
   array<double, 2> fermi_coords = da.getFermi2Femto(da.coord_system);
   double  c1 = fermi_coords[0], c2 = fermi_coords[1];
   double c2_upper_bound;
-  if (da.coord_system == CT){
+  if (da.coord_system == CT) {
     c2_upper_bound = 3;
-  } 
-  else {
-    c2_upper_bound = M_PI / 4.0;  
+  } else {
+    c2_upper_bound = M_PI / 4.0;
   }
 
   // define the cost function
   int num_residuals = da.xr_energies.size();
   ceres::Problem problem;
   auto * cost_function =
-    new ceres::NumericDiffCostFunction<CostFunctor, ceres::CENTRAL, ceres::DYNAMIC, 1, 1>(new CostFunctor(da),ceres::TAKE_OWNERSHIP ,num_residuals);
+    new ceres::NumericDiffCostFunction<CostFunctor, ceres::CENTRAL, ceres::DYNAMIC, 1, 1>(new CostFunctor(da),ceres::TAKE_OWNERSHIP,num_residuals);
   problem.AddResidualBlock(cost_function, nullptr, &c1, &c2);
 
-  // set minimisation algorithm 
+  // set minimisation algorithm
   ceres::MinimizerType minimizer;
-  if (algo == "lm"){    // levenberg marquardt
+  if (algo == "lm") {   // levenberg marquardt
     minimizer = ceres::TRUST_REGION;
 
     // set bounds for problem
@@ -265,7 +263,7 @@ void ceresOptimizeFermiParameters(DiracAtom & da, double & opt_time, const strin
     problem.SetParameterUpperBound(&c1,0, 7);
     problem.SetParameterUpperBound(&c2,0,c2_upper_bound);
     LOG(INFO) << "optimizing fermi parameters using the levenberg marquardt algorithm" ;
-  } else if (algo == "ls"){   // bfgs
+  } else if (algo == "ls") {  // bfgs
     minimizer = ceres::LINE_SEARCH;
     LOG(INFO) << "optimizing fermi parameters using the bfgs algorithm" ;
   }

--- a/lib/optimisation.cpp
+++ b/lib/optimisation.cpp
@@ -237,11 +237,31 @@ void ceresOptimizeFermiParameters(DiracAtom & da, double & opt_time, const strin
   // Get initial guess
   array<double, 2> fermi_coords = da.getFermi2(da.coord_system);
   double  c1 = fermi_coords[0], c2 = fermi_coords[1];
+  double c2_upper_bound;
+  if (da.coord_system == "ct"){
+    c2_upper_bound = 3;
+  } 
+  else {
+    c2_upper_bound = M_PI / 4.0;  
+  }
+
+  // define the cost function
+  int num_residuals = da.xr_energies.size();
+  ceres::Problem problem;
+  auto * cost_function =
+    new ceres::NumericDiffCostFunction<CostFunctor, ceres::CENTRAL, ceres::DYNAMIC, 1, 1>(new CostFunctor(da),ceres::TAKE_OWNERSHIP ,num_residuals);
+  problem.AddResidualBlock(cost_function, nullptr, &c1, &c2);
 
   // set minimisation algorithm 
   ceres::MinimizerType minimizer;
   if (algo == "lm"){    // levenberg marquardt
     minimizer = ceres::TRUST_REGION;
+
+    // set bounds for problem
+    problem.SetParameterLowerBound(&c1,0,0);
+    problem.SetParameterLowerBound(&c2,0,0);
+    problem.SetParameterUpperBound(&c1,0, 7);
+    problem.SetParameterUpperBound(&c2,0,c2_upper_bound);
     LOG(INFO) << "optimizing fermi parameters using the levenberg marquardt algorithm" ;
   } else if (algo == "ls"){   // bfgs
     minimizer = ceres::LINE_SEARCH;
@@ -252,12 +272,6 @@ void ceresOptimizeFermiParameters(DiracAtom & da, double & opt_time, const strin
   chrono::high_resolution_clock::time_point opt_t0, opt_t1;
   opt_t0 = chrono::high_resolution_clock::now();
 
-  // define the cost function
-  int num_residuals = da.xr_energies.size();
-  ceres::Problem problem;
-  auto * cost_function =
-    new ceres::NumericDiffCostFunction<CostFunctor, ceres::CENTRAL, ceres::DYNAMIC, 1, 1>(new CostFunctor(da),ceres::TAKE_OWNERSHIP ,num_residuals);
-  problem.AddResidualBlock(cost_function, nullptr, &c1, &c2);
 
   // set options and solve minimisation
   ceres::Solver::Options options;
@@ -268,6 +282,12 @@ void ceresOptimizeFermiParameters(DiracAtom & da, double & opt_time, const strin
   options.linear_solver_type = ceres::DENSE_QR;
 
   options.minimizer_progress_to_stdout = true;
+
+  options.line_search_interpolation_type = ceres::QUADRATIC;
+  options.max_num_line_search_step_size_iterations = 10;
+  options.line_search_sufficient_curvature_decrease = 0.90;
+  options.max_line_search_step_contraction = 0.1;
+  options.min_line_search_step_contraction = 0.5;
   ceres::Solver::Summary summary;
   ceres::Solve(options, &problem, &summary);
 

--- a/lib/optimisation.cpp
+++ b/lib/optimisation.cpp
@@ -198,7 +198,7 @@ void optFermi2(DiracAtom & da, const string algo, double & opt_time) {
     ceresOptimizeFermiParameters(da, opt_time, algo);
   } else {
     cout << "Invalid 2pF optimisation algorithm choice for minimsation\n";
-    cout << "please use \"bfgs\", \"trust\", or \"lm\" (default is \"bfgs\") \n";
+    cout << "please use \"lm\", \"ls\", \"bfgs\", or \"trust\", or (default is \"lm\") \n";
     cout << "You used: \""<<algo<<"\" \n";
     cout << "Quitting...\n";
     LOG(ERROR) << "Invalid 2pF optimisation algorithm choice for minimsation: \""<<algo<<"\"\n";
@@ -234,7 +234,7 @@ void runFermiModelOptimisation(MuDiracInputFile & config, const int & argc, char
 
 void ceresOptimizeFermiParameters(DiracAtom & da, double & opt_time, const string & algo) {
 
-  LOG(INFO) << "optimizing fermi parameters using the ceres software" ;
+  LOG(INFO) << "optimizing fermi parameters using the ceres software \n" ;
   // Get initial guess
   array<double, 2> fermi_coords = da.getFermi2Femto(da.coord_system);
   double  c1 = fermi_coords[0], c2 = fermi_coords[1];

--- a/lib/optimisation.cpp
+++ b/lib/optimisation.cpp
@@ -236,8 +236,7 @@ void ceresOptimizeFermiParameters(DiracAtom & da, double & opt_time, const strin
   LOG(INFO) << "optimizing fermi parameters using the ceres software" ;
   // Get initial guess
   array<double, 2> fermi_coords = da.getFermi2(da.coord_system);
-  double c1 = fermi_coords[0];
-  double c2 = fermi_coords[1];
+  double  c1 = fermi_coords[0], c2 = fermi_coords[1];
 
   // set minimisation algorithm 
   ceres::MinimizerType minimizer;
@@ -254,9 +253,10 @@ void ceresOptimizeFermiParameters(DiracAtom & da, double & opt_time, const strin
   opt_t0 = chrono::high_resolution_clock::now();
 
   // define the cost function
+  int num_residuals = da.xr_energies.size();
   ceres::Problem problem;
-  ceres::CostFunction * cost_function =
-    new ceres::NumericDiffCostFunction<CostFunctor, ceres::CENTRAL, 1, 1, 1>(new CostFunctor(da));
+  auto * cost_function =
+    new ceres::NumericDiffCostFunction<CostFunctor, ceres::CENTRAL, ceres::DYNAMIC, 1, 1>(new CostFunctor(da),ceres::TAKE_OWNERSHIP ,num_residuals);
   problem.AddResidualBlock(cost_function, nullptr, &c1, &c2);
 
   // set options and solve minimisation
@@ -264,23 +264,16 @@ void ceresOptimizeFermiParameters(DiracAtom & da, double & opt_time, const strin
   options.minimizer_type = minimizer;
   options.gradient_tolerance =1e-5;
   options.parameter_tolerance = 1e-5;
-  // options.function_tolerance = 1e-5;
+  options.min_relative_decrease = 1e-2;
+  options.linear_solver_type = ceres::DENSE_QR;
 
-  options.line_search_interpolation_type = ceres::QUADRATIC;
-  options.max_num_line_search_step_size_iterations = 100;
-  options.line_search_sufficient_function_decrease = 1e-6;
-  options.min_line_search_step_size = 1e-5;
-
-  // options.initial_trust_region_radius = 10;
   options.minimizer_progress_to_stdout = true;
   ceres::Solver::Summary summary;
   ceres::Solve(options, &problem, &summary);
 
-  // the final cost is calcuated as the least square of the residual. ie 1/2 (.)**2
-  // could rewrite so calculate MSE is not required/ all handled by ceres
   opt_t1 = chrono::high_resolution_clock::now();
-  std::cout << summary.BriefReport() << "\n";
+  std::cout << summary.FullReport() << "\n";
   opt_time = chrono::duration_cast<chrono::milliseconds>(opt_t1 - opt_t0).count() / 1.0e3;
-  finaliseFermi2(da, da.coord_system, {c1, c2}, opt_time, sqrt(2*summary.final_cost));
+  finaliseFermi2(da, da.coord_system, {c1, c2}, opt_time, summary.final_cost*2.0/double(num_residuals));
 
 }

--- a/lib/optimisation.cpp
+++ b/lib/optimisation.cpp
@@ -193,8 +193,8 @@ void optFermi2(DiracAtom & da, const string algo, double & opt_time) {
     trustOptimizeFermiParameters(opt_obj, da, opt_time);
   } else if (algo=="global") {
     globalOptimizeFermiParameters(da, opt_time);
-  } else if (algo=="lm") {
-    lmOptimizeFermiParameters(da, opt_time);
+  } else if ((algo=="lm")|| (algo=="ls")){
+    ceresOptimizeFermiParameters(da, opt_time, algo);
   } 
   else {
     cout << "Invalid 2pF optimisation algorithm choice for minimsation\n";
@@ -231,13 +231,23 @@ void runFermiModelOptimisation(MuDiracInputFile & config, const int & argc, char
   writeFermiParameters(da, opt_time,  seed + "fermi_parameters.out", config.getIntValue("rms_radius_decimals"));
 }
 
-void lmOptimizeFermiParameters(DiracAtom & da, double & opt_time){
+void ceresOptimizeFermiParameters(DiracAtom & da, double & opt_time, const string & algo){
 
-  LOG(INFO) << "optimizing fermi parameters using the ceres lm algorithm" ;
+  LOG(INFO) << "optimizing fermi parameters using the ceres software" ;
   // Get initial guess
   array<double, 2> fermi_coords = da.getFermi2(da.coord_system);
   double c1 = fermi_coords[0];
   double c2 = fermi_coords[1];
+
+  // set minimisation algorithm 
+  ceres::MinimizerType minimizer;
+  if (algo == "lm"){    // levenberg marquardt
+    minimizer = ceres::TRUST_REGION;
+    LOG(INFO) << "optimizing fermi parameters using the levenberg marquardt algorithm" ;
+  } else if (algo == "ls"){   // bfgs
+    minimizer = ceres::LINE_SEARCH;
+    LOG(INFO) << "optimizing fermi parameters using the bfgs algorithm" ;
+  }
 
   // start time of minimisation
   chrono::high_resolution_clock::time_point opt_t0, opt_t1;
@@ -251,6 +261,7 @@ void lmOptimizeFermiParameters(DiracAtom & da, double & opt_time){
 
   // set options and solve minimisation
   ceres::Solver::Options options;
+  options.minimizer_type = minimizer;
   options.gradient_tolerance =0.01;
   options.parameter_tolerance = 1e-5;
   options.function_tolerance = 1e-2;

--- a/lib/optimisation.cpp
+++ b/lib/optimisation.cpp
@@ -262,9 +262,9 @@ void ceresOptimizeFermiParameters(DiracAtom & da, double & opt_time, const strin
   // set options and solve minimisation
   ceres::Solver::Options options;
   options.minimizer_type = minimizer;
-  options.gradient_tolerance =0.01;
+  options.gradient_tolerance =1e-5;
   options.parameter_tolerance = 1e-5;
-  options.function_tolerance = 1e-2;
+  options.function_tolerance = 1e-5;
   ceres::Solver::Summary summary;
   ceres::Solve(options, &problem, &summary);
 

--- a/lib/optimisation.cpp
+++ b/lib/optimisation.cpp
@@ -193,9 +193,12 @@ void optFermi2(DiracAtom & da, const string algo, double & opt_time) {
     trustOptimizeFermiParameters(opt_obj, da, opt_time);
   } else if (algo=="global") {
     globalOptimizeFermiParameters(da, opt_time);
-  } else {
+  } else if (algo=="lm") {
+    lmOptimizeFermiParameters(da, opt_time);
+  } 
+  else {
     cout << "Invalid 2pF optimisation algorithm choice for minimsation\n";
-    cout << "please use \"bfgs\" or \"trust\" (default is \"bfgs\") \n";
+    cout << "please use \"bfgs\", \"trust\", or \"lm\" (default is \"bfgs\") \n";
     cout << "You used: \""<<algo<<"\" \n";
     cout << "Quitting...\n";
     LOG(ERROR) << "Invalid 2pF optimisation algorithm choice for minimsation: \""<<algo<<"\"\n";
@@ -228,3 +231,37 @@ void runFermiModelOptimisation(MuDiracInputFile & config, const int & argc, char
   writeFermiParameters(da, opt_time,  seed + "fermi_parameters.out", config.getIntValue("rms_radius_decimals"));
 }
 
+void lmOptimizeFermiParameters(DiracAtom & da, double & opt_time){
+
+  LOG(INFO) << "optimizing fermi parameters using the ceres lm algorithm" ;
+  // Get initial guess
+  array<double, 2> fermi_coords = da.getFermi2(da.coord_system);
+  double c1 = fermi_coords[0];
+  double c2 = fermi_coords[1];
+
+  // start time of minimisation
+  chrono::high_resolution_clock::time_point opt_t0, opt_t1;
+  opt_t0 = chrono::high_resolution_clock::now();
+
+  // define the cost function
+  ceres::Problem problem;
+  ceres::CostFunction * cost_function =
+    new ceres::NumericDiffCostFunction<CostFunctor, ceres::CENTRAL, 1, 1, 1>(new CostFunctor(da));
+  problem.AddResidualBlock(cost_function, nullptr, &c1, &c2);
+
+  // set options and solve minimisation
+  ceres::Solver::Options options;
+  options.gradient_tolerance =0.01;
+  options.parameter_tolerance = 1e-5;
+  options.function_tolerance = 1e-2;
+  ceres::Solver::Summary summary;
+  ceres::Solve(options, &problem, &summary);
+
+  // the final cost is calcuated as the least square of the residual. ie 1/2 (.)**2
+  // could rewrite so calculate MSE is not required/ all handled by ceres
+  opt_t1 = chrono::high_resolution_clock::now();
+  std::cout << summary.BriefReport() << "\n";
+  opt_time = chrono::duration_cast<chrono::milliseconds>(opt_t1 - opt_t0).count() / 1.0e3;
+  finaliseFermi2(da, da.coord_system, {c1, c2}, opt_time, sqrt(2*summary.final_cost));
+
+}

--- a/lib/optimisation.cpp
+++ b/lib/optimisation.cpp
@@ -264,7 +264,15 @@ void ceresOptimizeFermiParameters(DiracAtom & da, double & opt_time, const strin
   options.minimizer_type = minimizer;
   options.gradient_tolerance =1e-5;
   options.parameter_tolerance = 1e-5;
-  options.function_tolerance = 1e-5;
+  // options.function_tolerance = 1e-5;
+
+  options.line_search_interpolation_type = ceres::QUADRATIC;
+  options.max_num_line_search_step_size_iterations = 100;
+  options.line_search_sufficient_function_decrease = 1e-6;
+  options.min_line_search_step_size = 1e-5;
+
+  // options.initial_trust_region_radius = 10;
+  options.minimizer_progress_to_stdout = true;
   ceres::Solver::Summary summary;
   ceres::Solve(options, &problem, &summary);
 

--- a/lib/optimisation.hpp
+++ b/lib/optimisation.hpp
@@ -9,13 +9,15 @@
  * @author Milan Kumar
  * @version 1.0 30/06/2025
  */
-
+#include "ceres/ceres.h"
+#undef LOG
 #include <dlib/optimization.h>
 #include <dlib/global_optimization.h>
 #include "atom.hpp"
 #include "config.hpp"
 #include "experiment.hpp"
 #include "output.hpp"
+
 
 
 typedef dlib::matrix<double,0,1> column_vector;
@@ -188,3 +190,18 @@ void optFermi2(DiracAtom & da, const string algo, double & opt_time);
  * @retval None
  */
 void runFermiModelOptimisation(MuDiracInputFile & config, const int & argc, char * argv[], DiracAtom &da, const string & seed);
+
+// Ceres optimisation problem things
+struct CostFunctor {
+  mutable DiracAtom ma;
+
+  CostFunctor(DiracAtom &da_in) : ma(da_in) {}
+
+  template <typename T>
+  bool operator() (const T* const c1, const T* const c2, T* residual) const {
+    residual[0] = ma.calculateMSE(c1[0], c2[0]);
+    return true;
+  }
+};
+
+void lmOptimizeFermiParameters(DiracAtom & da, double & opt_time);

--- a/lib/optimisation.hpp
+++ b/lib/optimisation.hpp
@@ -204,4 +204,4 @@ struct CostFunctor {
   }
 };
 
-void lmOptimizeFermiParameters(DiracAtom & da, double & opt_time);
+void ceresOptimizeFermiParameters(DiracAtom & da, double & opt_time,const  string & algo);

--- a/lib/optimisation.hpp
+++ b/lib/optimisation.hpp
@@ -197,9 +197,32 @@ struct CostFunctor {
 
   CostFunctor(DiracAtom &da_in) : ma(da_in) {}
 
-  template <typename T>
-  bool operator() (const T* const c1, const T* const c2, T* residual) const {
-    residual[0] = ma.calculateMSE(c1[0], c2[0]);
+
+  bool operator() (const double* const c1, const double* const c2, double* residual) const {
+    ma.setFermi2(c1[0], c2[0], ma.coord_system);
+    vector<TransitionData> transitions_iteration = ma.getAllTransitions();
+
+    for (int k = 0; k < transitions_iteration.size(); ++k) {
+      // calculate transition energy and rate
+      double dE = (transitions_iteration[k].ds2.E - transitions_iteration[k].ds1.E);
+      double tRate = transitions_iteration[k].tmat.totalRate();
+
+
+      if (dE <= 0 || tRate <= 0)
+        continue; // Transition is invisible
+
+      // check transition allign with experimental transitions
+      if (transitions_iteration[k].name == ma.xr_lines_measured[k]) {
+        // convert to eV
+        double transition_energy = dE / Physical::eV;
+
+        // calculate the square error of each transition
+        //double square_deviation = (transition_energy-xr_energies[k])*(transition_energy-xr_energies[k]);
+        //double valid_uncertainty = (xr_errors[k])*(xr_errors[k]);
+        //square_error = square_deviation/valid_uncertainty;
+        residual[k] = (transition_energy - ma.xr_energies[k])/ma.xr_errors[k];
+      }
+    }
     return true;
   }
 };

--- a/lib/optimisation.hpp
+++ b/lib/optimisation.hpp
@@ -20,7 +20,7 @@
 
 
 
-typedef dlib::matrix<double,0,1> column_vector;
+typedef dlib::matrix<double,2,1> column_vector;
 
 /**
  * @brief a function which outputs optimisation results to LOG and sets finalised optimisation data values in a dirac atom.


### PR DESCRIPTION
This PR adds the capability to use Ceres solver in the 2 parameter Fermi model optimisation. The Levenberg-Marquardt algorithm used in Ceres solver is significantly faster at solving the least squares minimisation problem than the previous BFGS method using dlib. 

To use this functionality Ceres solver should already be installed. Installation instructions are found here: http://ceres-solver.org/installation.html

Using Ceres solver also makes it easy to benchmark further algorithms and add uncertainty estimation using Covariance. These additional features can be included in further updates.