### PR TITLE
Fix: Build for MacOs

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -79,10 +79,17 @@ target_link_libraries(optimisation Ceres::ceres experiment)
 
 # Define interface library
 add_library(mudiraclib INTERFACE)
-target_link_libraries(mudiraclib INTERFACE
-  $<LINK_GROUP:RESCAN,
-    debugtasks,config,experiment,output,
-    atom,boundary,state,potential,
-    econfigs,hydrogenic,transforms,
-    wavefunction,integrate,elements,input,utils,optimisation
-  >)
+set(MUDIRAC_LIBS
+  debugtasks config experiment output
+  atom boundary state potential
+  econfigs hydrogenic transforms
+  wavefunction integrate elements input utils optimisation)
+# GNU ld resolves static library symbols in a single pass, so the libraries
+# must be wrapped in a RESCAN group; other linkers (e.g. Apple ld64) don't
+# support the feature and don't need it.
+if(CMAKE_CXX_LINK_GROUP_USING_RESCAN_SUPPORTED OR CMAKE_LINK_GROUP_USING_RESCAN_SUPPORTED)
+  string(JOIN "," MUDIRAC_LIBS_GROUP ${MUDIRAC_LIBS})
+  target_link_libraries(mudiraclib INTERFACE "$<LINK_GROUP:RESCAN,${MUDIRAC_LIBS_GROUP}>")
+else()
+  target_link_libraries(mudiraclib INTERFACE ${MUDIRAC_LIBS})
+endif()

--- a/lib/elements.cpp
+++ b/lib/elements.cpp
@@ -74,16 +74,14 @@ double getIsotopeRadius(int Z, int isotope) {
 }
 
 vector<int> getAllIsotopes(string symbol) {
-  map<int, isotope> isos;
+  vector<int> isoA;
   try {
-    isos = atomic_data.at(symbol).isotopes;
+    const map<int, isotope> &isos = atomic_data.at(symbol).isotopes;
+    for (map<int, isotope>::const_iterator it = isos.begin(); it != isos.end(); ++it) {
+      isoA.push_back(it->first);
+    }
   } catch (out_of_range e) {
     throw invalid_argument("Element does not exist");
-  }
-
-  vector<int> isoA;
-  for (map<int, isotope>::iterator it = isos.begin(); it != isos.end(); ++it) {
-    isoA.push_back(it->first);
   }
   sort(isoA.begin(), isoA.end());
 


### PR DESCRIPTION
Instead of copying element map referencing it was failing in Mac.
 RESCAN only for linux